### PR TITLE
fix(SA-603): adding config delegated admin to the delegated module

### DIFF
--- a/modules/delegation/README.md
+++ b/modules/delegation/README.md
@@ -19,18 +19,47 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 3. Run `terraform-docs markdown table --output-file ${PWD}/README.md --output-mode inject .`
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_auditmanager_organization_admin_account_registration.audit_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/auditmanager_organization_admin_account_registration) | resource |
+| [aws_detective_organization_admin_account.detective_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/detective_organization_admin_account) | resource |
+| [aws_fms_admin_account.fms_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account) | resource |
+| [aws_guardduty_organization_admin_account.guardduty_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_admin_account) | resource |
+| [aws_iam_service_linked_role.access_analyzer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
+| [aws_inspector2_delegated_admin_account.inspection_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_delegated_admin_account) | resource |
+| [aws_macie2_account.macie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account) | resource |
+| [aws_macie2_organization_admin_account.macie_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_organization_admin_account) | resource |
+| [aws_organizations_delegated_administrator.access_analyzer_administrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
+| [aws_organizations_delegated_administrator.delegated_administrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
+| [aws_organizations_delegated_administrator.stacksets_administrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_delegated_administrator) | resource |
+| [aws_securityhub_organization_admin_account.securityhub_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_organization_admin_account) | resource |
+| [aws_vpc_ipam_organization_admin_account.ipam_organization_admin_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipam_organization_admin_account) | resource |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_delegation"></a> [enable\_delegation](#input\_enable\_delegation) | Provides at the capability to delegate the management of a service to another AWS account. | <pre>object({<br/>    access_analyzer = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Access Analyzer to<br/>    }), null)<br/>    audit_manager = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Audit Manager to<br/>    }), null)<br/>    detective = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Detective to<br/>    }), null)<br/>    firewall_manager = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Firewall Manager to<br/>    }), null)<br/>    guardduty = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of GuardDuty to<br/>    }), null)<br/>    inspector = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Inspector to<br/>    }), null)<br/>    ipam = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of IPAM to<br/>    }), null)<br/>    organizations = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Organizations to<br/>    }), null)<br/>    macie = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Macie to<br/>    }), null)<br/>    securityhub = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Security Hub to<br/>    }), null)<br/>    stacksets = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of StackSets to<br/>    }), null)<br/>    config = optional(object({<br/>      account_id = string<br/>      # The id of the account to delegate the management of Config to<br/>    }), null)<br/>  })</pre> | <pre>{<br/>  "access_analyzer": null,<br/>  "audit_manager": null,<br/>  "config": null,<br/>  "detective": null,<br/>  "firewall_manager": null,<br/>  "guardduty": null,<br/>  "inspector": null,<br/>  "ipam": null,<br/>  "macie": null,<br/>  "organizations": null,<br/>  "securityhub": null,<br/>  "stacksets": null<br/>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to resources provisioned by this module. | `map(string)` | n/a | yes |
-| <a name="input_enable_delegation"></a> [enable\_delegation](#input\_enable\_delegation) | Provides at the capability to delegate the management of a service to another AWS account. | <pre>object({<br/>    access_analyzer = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Access Analyzer to<br/>    }), null)<br/>    audit_manager = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Audit Manager to<br/>    }), null)<br/>    detective = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Detective to<br/>    }), null)<br/>    firewall_manager = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Firewall Manager to<br/>    }), null)<br/>    guardduty = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of GuardDuty to<br/>    }), null)<br/>    inspector = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Inspector to<br/>    }), null)<br/>    ipam = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of IPAM to<br/>    }), null)<br/>    organizations = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Organizations to<br/>    }), null)<br/>    macie = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Macie to<br/>    }), null)<br/>    securityhub = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of Security Hub to<br/>    }), null)<br/>    stacksets = optional(object({<br/>      account_id = string<br/>      # The account id of the account to delegate the management of StackSets to<br/>    }), null)<br/>  })</pre> | <pre>{<br/>  "access_analyzer": null,<br/>  "audit_manager": null,<br/>  "detective": null,<br/>  "firewall_manager": null,<br/>  "guardduty": null,<br/>  "inspector": null,<br/>  "ipam": null,<br/>  "macie": null,<br/>  "organizations": null,<br/>  "securityhub": null,<br/>  "stacksets": null<br/>}</pre> | no |
 
 ## Outputs
 

--- a/modules/delegation/main.tf
+++ b/modules/delegation/main.tf
@@ -93,3 +93,10 @@ resource "aws_inspector2_delegated_admin_account" "inspection_organization_admin
 
   account_id = var.enable_delegation.inspector.account_id
 }
+
+resource "aws_organizations_delegated_administrator" "config_administrator" {
+  count = var.enable_delegation.config != null ? 1 : 0
+
+  account_id        = var.enable_delegation.config.account_id
+  service_principal = "config.amazonaws.com"
+}

--- a/modules/delegation/variables.tf
+++ b/modules/delegation/variables.tf
@@ -51,6 +51,10 @@ variable "enable_delegation" {
       account_id = string
       # The account id of the account to delegate the management of StackSets to
     }), null)
+    config = optional(object({
+      account_id = string
+      # The id of the account to delegate the management of Config to
+    }), null)
   })
   default = {
     access_analyzer  = null
@@ -64,5 +68,6 @@ variable "enable_delegation" {
     organizations    = null
     securityhub      = null
     stacksets        = null
+    config           = null 
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,6 @@ variable "enable_delegation" {
     organizations   = null
     securityhub     = null
     stacksets       = null
-    config       = null
+    config          = null
   }
 }


### PR DESCRIPTION
https://appvia.atlassian.net/browse/SA-603

* Wasn't seeing any delegate admin activities in the terraform plan from `lz-aws-organizations`
  * Until Rohith highlighted that we have both a root delegation.tf and a delegation module.
  * `lz-aws-organizations` is coming the delegation module.
    * These changes represent the same config delegation change - but at the module level


---

* Workflow 
* No terraform plan as this is a module
* No examples that consume from the module - rather than the root