### PR TITLE
chore: add pinDigests for github-actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,13 @@
     "config:recommended",
     ":semanticCommitTypeAll(chore)",
     "schedule:earlyMondays"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
Adds `pinDigests: true` for the `github-actions` Renovate manager so reusable workflow references to `appvia/appvia-cicd-workflows` are pinned to immutable commit SHAs. Renovate will raise a follow-up PR to pin existing refs. Part of SA-689.